### PR TITLE
perf(session.service.ts): removes unneeded fields from session creati…

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -68,7 +68,7 @@ ownerInstance.interceptors.response.use(
       });
 
       const { data } = res;
-      console.log(data);
+
       if (res.status === 200) {
         const { access_token, refresh_token } = data;
         await teslaAccountController.updateTeslaAccount({ access_token, refresh_token, _id }, vehicle);

--- a/src/models/session.model.ts
+++ b/src/models/session.model.ts
@@ -83,8 +83,7 @@ const sessionSchema = new Schema({
 
 sessionSchema.plugin(objectIdToString());
 
-sessionSchema.index({ vehicle: 1, _id: -1 });
-sessionSchema.index({ vehicle: 1, type: 1 });
+sessionSchema.index({ _id: -1, vehicle: 1, user: 1, type: 1 });
 /**
  * @typedef Session
  */

--- a/src/services/mapPoint.service.ts
+++ b/src/services/mapPoint.service.ts
@@ -1,4 +1,6 @@
 import { Document } from 'mongoose';
+import { performance } from 'perf_hooks';
+
 import { MapPoint } from '../models';
 import { IMapPoint } from '../models/mapPoint.model';
 import { toFixedWithoutRounding } from '../utils/formatFuncs';
@@ -7,6 +9,7 @@ import Logger from '../config/logger';
 const logger = Logger('mapPoint.service');
 
 const saveMapPoint = async (vehicleData: Document): Promise<IMapPoint | null> => {
+  const startTime = performance.now();
   const { _id, vehicle, user, drive_state } = vehicleData.toJSON();
   const { longitude, latitude } = drive_state;
 
@@ -53,11 +56,14 @@ const saveMapPoint = async (vehicleData: Document): Promise<IMapPoint | null> =>
     },
     { upsert: true, new: true }
   );
+  const endTime = performance.now();
 
   logger.info(`${mapPoint.visitCount === 1 ? 'inserted' : 'updated'} map point`, {
     _id: mapPoint._id,
     vehicle: mapPoint.vehicle,
   });
+  logger.debug(`Call to saveMapPoint took ${endTime - startTime} milliseconds`);
+
   return mapPoint;
 };
 

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -43,7 +43,7 @@ const upsertSessionById = async (
             },
           },
         },
-        { upsert: true, new: true }
+        { upsert: true, new: true, select: '_id createdAt updatedAt' }
       );
       const cacheKey = buildCacheKey(session.vehicle, `${SessionType[type]}-session`);
       await cacheService.setCache(cacheKey, session, ttl);
@@ -79,7 +79,7 @@ const upsertSessionById = async (
             startLocation: { type: 'Point', coordinates: [drive_state.longitude, drive_state.latitude] },
           },
         },
-        { upsert: true, new: true }
+        { upsert: true, new: true, select: '_id createdAt updatedAt' }
       );
       break;
     }
@@ -90,9 +90,9 @@ const upsertSessionById = async (
   }
   const endTime = performance.now();
 
-  logger.info(`${session.dataPoints.length <= 1 ? 'inserted' : 'updated'} session`, {
+  logger.info(`${session.createdAt === session.updatedAt ? 'inserted' : 'updated'} session`, {
     _id: session._id,
-    vehicle: session.vehicle,
+    vehicle,
     type: SessionType[type],
   });
 


### PR DESCRIPTION
…on return object

the return object from creating/updating a document will now only return the _id, createdAt, and
updated at fields